### PR TITLE
added true airgap support for rhel

### DIFF
--- a/examples/aws/centos.auto.tfvars.example
+++ b/examples/aws/centos.auto.tfvars.example
@@ -1,4 +1,6 @@
 aws_region = "us-east-1"
+# Use ami-02eac2c0129f6376b for online
+# Use ami-003969f560bcf23a2 for airgapped
 aws_instance_ami = "ami-02eac2c0129f6376b"
 # Use m5.large for POCs
 # Use m5.large, m5.xlarge or m5.2xlarge for production

--- a/examples/aws/pes/main.tf
+++ b/examples/aws/pes/main.tf
@@ -133,7 +133,7 @@ resource "aws_lb_target_group" "ptfe_8800" {
   target_type        = "instance"
 
   health_check {
-  path      = "/"
+  path      = "/_health_check"
   protocol  = "HTTPS"
   matcher   = "200"
   }

--- a/examples/aws/rhel.auto.tfvars.example
+++ b/examples/aws/rhel.auto.tfvars.example
@@ -1,5 +1,7 @@
 aws_region = "us-east-1"
-aws_instance_ami = "ami-011b3ccf1bd6db744"
+# Use ami-011b3ccf1bd6db744 for online
+# Use ami-0d355a64b6e6b7bf9 for airgapped
+aws_instance_ami = "ami-0d355a64b6e6b7bf9"
 # Use m5.large for POCs
 # Use m5.large, m5.xlarge or m5.2xlarge for production
 aws_instance_type = "m5.large"

--- a/examples/aws/user-data-centos-online.tpl
+++ b/examples/aws/user-data-centos-online.tpl
@@ -16,7 +16,7 @@ cat > /etc/replicated.conf <<EOF
   "TlsBootstrapType": "self-signed",
   "ImportSettingsFrom": "/home/centos/ptfe-settings.json",
   "LicenseFileLocation": "/home/centos/ptfe-license.rli",
-  "BypassPreflightChecks": false
+  "BypassPreflightChecks": true
 }
 EOF
 

--- a/examples/aws/user-data-rhel-online.tpl
+++ b/examples/aws/user-data-rhel-online.tpl
@@ -16,7 +16,7 @@ cat > /etc/replicated.conf <<EOF
   "TlsBootstrapType": "self-signed",
   "ImportSettingsFrom": "/home/ec2-user/ptfe-settings.json",
   "LicenseFileLocation": "/home/ec2-user/ptfe-license.rli",
-  "BypassPreflightChecks": false
+  "BypassPreflightChecks": true
 }
 EOF
 

--- a/examples/aws/user-data-ubuntu-airgapped.tpl
+++ b/examples/aws/user-data-ubuntu-airgapped.tpl
@@ -17,7 +17,7 @@ cat > /etc/replicated.conf <<EOF
   "ImportSettingsFrom": "/home/ubuntu/ptfe-settings.json",
   "LicenseFileLocation": "/home/ubuntu/ptfe-license.rli",
   "LicenseBootstrapAirgapPackagePath": "/home/ubuntu/${airgap_bundle}",
-  "BypassPreflightChecks": false
+  "BypassPreflightChecks": true
 }
 EOF
 
@@ -149,6 +149,10 @@ aws s3 cp s3://${source_bucket_name}/${docker_package} /home/ubuntu/${docker_pac
 
 # Install Docker
 DEBIAN_FRONTEND=noninteractive dpkg --install /home/ubuntu/${docker_package}
+
+# Start Docker and make it a service
+systemctl enable docker
+systemctl start docker
 
 # Download the Airgap bundle
 aws s3 cp s3://${source_bucket_name}/${airgap_bundle} /home/ubuntu/${airgap_bundle}

--- a/examples/aws/user-data-ubuntu-online.tpl
+++ b/examples/aws/user-data-ubuntu-online.tpl
@@ -16,7 +16,7 @@ cat > /etc/replicated.conf <<EOF
   "TlsBootstrapType": "self-signed",
   "ImportSettingsFrom": "/home/ubuntu/ptfe-settings.json",
   "LicenseFileLocation": "/home/ubuntu/ptfe-license.rli",
-  "BypassPreflightChecks": false
+  "BypassPreflightChecks": true
 }
 EOF
 


### PR DESCRIPTION
Added true airgap support for RHEL and created AMIs that can be used which already include Docker, AWS CLI, and psql pre-installed.  So, the only things needed in PTFE Source bucket are the airgap bundle, replicated.tar.gz, and a license file.