### PR TITLE
curl against private ID, not DNS

### DIFF
--- a/examples/aws/user-data-centos-airgapped.tpl
+++ b/examples/aws/user-data-centos-airgapped.tpl
@@ -142,7 +142,7 @@ else
 fi
 
 # Check status of install
-while ! curl -ksfS --connect-timeout 5 https://${hostname}/_health_check; do
+while ! curl -ksfS --connect-timeout 5 https://$PRIVATE_IP/_health_check; do
     sleep 15
 done
 

--- a/examples/aws/user-data-centos-online.tpl
+++ b/examples/aws/user-data-centos-online.tpl
@@ -6,7 +6,10 @@ exec > /home/centos/install-ptfe.log 2>&1
 # Get private and public IPs of the EC2 instance
 PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
 PRIVATE_DNS=$(curl http://169.254.169.254/latest/meta-data/local-hostname)
-PUBLIC_IP=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)
+
+if [ "${public_ip}" == "true" ]; then
+  PUBLIC_IP=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)
+fi
 
 # Write out replicated.conf configuration file
 cat > /etc/replicated.conf <<EOF
@@ -129,18 +132,24 @@ PGPASSWORD=${pg_password} psql -h $host -p $port -d ${pg_dbname} -U ${pg_user} -
 
 # Install PTFE
 curl https://install.terraform.io/ptfe/stable > /home/centos/install.sh
-
-bash /home/centos/install.sh \
+if [ "${public_ip}" == "true" ]; then
+  bash /home/centos/install.sh \
+    no-proxy \
+    private-address=$PRIVATE_IP \
+    public-address=$PUBLIC_IP
+else
+  bash /home/centos/install.sh \
   no-proxy \
-  private-address=$PRIVATE_IP\
-  public-address=$PUBLIC_IP
+  private-address=$PRIVATE_IP \
+  public-address=$PRIVATE_IP
+fi
 
 # Allow centos user to use docker
 # This will not take effect until after you logout and back in
 usermod -aG docker centos
 
 # Check status of install
-while ! curl -ksfS --connect-timeout 5 https://${hostname}/_health_check; do
+while ! curl -ksfS --connect-timeout 5 https://$PRIVATE_IP/_health_check; do
     sleep 15
 done
 

--- a/examples/aws/user-data-rhel-airgapped.tpl
+++ b/examples/aws/user-data-rhel-airgapped.tpl
@@ -142,7 +142,7 @@ else
 fi
 
 # Check status of install
-while ! curl -ksfS --connect-timeout 5 https://${hostname}/_health_check; do
+while ! curl -ksfS --connect-timeout 5 https://$PRIVATE_IP/_health_check; do
     sleep 15
 done
 

--- a/examples/aws/user-data-rhel-online.tpl
+++ b/examples/aws/user-data-rhel-online.tpl
@@ -6,7 +6,10 @@ exec > /home/ec2-user/install-ptfe.log 2>&1
 # Get private and public IPs of the EC2 instance
 PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
 PRIVATE_DNS=$(curl http://169.254.169.254/latest/meta-data/local-hostname)
-PUBLIC_IP=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)
+
+if [ "${public_ip}" == "true" ]; then
+  PUBLIC_IP=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)
+fi
 
 # Write out replicated.conf configuration file
 cat > /etc/replicated.conf <<EOF
@@ -126,18 +129,24 @@ PGPASSWORD=${pg_password} psql -h $host -p $port -d ${pg_dbname} -U ${pg_user} -
 
 # Install PTFE
 curl https://install.terraform.io/ptfe/stable > /home/ec2-user/install.sh
-
-bash /home/ec2-user/install.sh \
-  no-proxy \
-  private-address=$PRIVATE_IP\
-  public-address=$PUBLIC_IP
+if [ "${public_ip}" == "true" ]; then
+  bash /home/ec2-user/install.sh \
+    no-proxy \
+    private-address=$PRIVATE_IP \
+    public-address=$PUBLIC_IP
+else
+  bash /home/ec2-user/install.sh \
+    no-proxy \
+    private-address=$PRIVATE_IP \
+    public-address=$PRIVATE_IP
+fi
 
 # Allow ec2-user user to use docker
 # This will not take effect until after you logout and back in
 usermod -aG docker ec2-user
 
 # Check status of install
-while ! curl -ksfS --connect-timeout 5 https://${hostname}/_health_check; do
+while ! curl -ksfS --connect-timeout 5 https://$PRIVATE_IP/_health_check; do
     sleep 15
 done
 

--- a/examples/aws/user-data-ubuntu-airgapped.tpl
+++ b/examples/aws/user-data-ubuntu-airgapped.tpl
@@ -142,7 +142,7 @@ else
 fi
 
 # Check status of install
-while ! curl -ksfS --connect-timeout 5 https://${hostname}/_health_check; do
+while ! curl -ksfS --connect-timeout 5 https://$PRIVATE_IP/_health_check; do
     sleep 15
 done
 

--- a/examples/aws/variables.tf
+++ b/examples/aws/variables.tf
@@ -120,7 +120,7 @@ variable "linux" {
 ### Variables for user_data script that installs PTFE
 
 variable "ptfe_admin_password" {
-  # Any characters
+  # Any characters, at least 8 of them
   description = "password for PTFE admin console (at port 8800)"
 }
 
@@ -157,6 +157,7 @@ variable "capacity_memory" {
 }
 
 variable "enc_password" {
+  # Any characters, at least 8 of them
   description = "Set the encryption password for the install"
 }
 
@@ -188,7 +189,7 @@ variable "pg_password" {
 }
 
 variable "pg_user" {
-  # Can only contain alphanumeric characters
+  # Can only contain alphanumeric characters, at least 8 of them
   description = "Name of PostgreSQL database user"
   default = "ptfe"
 }
@@ -282,6 +283,7 @@ variable "create_first_user_and_org" {
 }
 
 variable "initial_admin_username" {
+  # alphanumeric, at least 8 characters
   description = "username of initial site admin user in PTFE"
 }
 
@@ -290,10 +292,12 @@ variable "initial_admin_email" {
 }
 
 variable "initial_admin_password" {
+  # any characters, at least 8 of them
   description = "username of initial site admin user in PTFE"
 }
 
 variable "initial_org_name" {
+  # alphanumeric and hyphens
   description = "name of initial organization in PTFE"
 }
 


### PR DESCRIPTION
That way, if there is no outbound internet access from the PTFE instances, the curl calls can still complete successfully once PTFE app is running.