### PR TITLE
Add the Service Principal Application id to the access policy.

### DIFF
--- a/examples/bootstrap-azure/README.md
+++ b/examples/bootstrap-azure/README.md
@@ -11,6 +11,7 @@ The only required inputs are a object-id and tenant-id to give access to the key
 |------|-------------|:----:|:-----:|:-----:|
 | key\_vault\_object\_id | The object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. | string | n/a | yes |
 | key\_vault\_tenant\_id | The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault. | string | n/a | yes |
+| application\_id | The application ID of the service principal for the vault. | string | n/a | yes |
 | additional\_tags | A map of additional tags to attach to all resources created. | map | `{}` | no |
 | address\_space | CIDR block range to use for the network. | string | `"10.0.0.0/16"` | no |
 | address\_space\_allowlist | CIDR block range to use to allow traffic from | string | `"*"` | no |

--- a/examples/bootstrap-azure/key_vault.tf
+++ b/examples/bootstrap-azure/key_vault.tf
@@ -7,28 +7,62 @@ resource "azurerm_key_vault" "new" {
   tags                            = "${local.tags}"
   enabled_for_deployment          = true
   enabled_for_template_deployment = true
+}
 
-  access_policy {
-    tenant_id = "${var.key_vault_tenant_id}"
-    object_id = "${var.key_vault_object_id}"
 
-    certificate_permissions = [
-      "get",
-      "list",
-      "create",
-      "delete",
-    ]
+resource "azurerm_key_vault_access_policy" "new-user" {
+  key_vault_id = "${azurerm_key_vault.new.id}"
+  tenant_id = "${var.key_vault_tenant_id}"
+  object_id = "${var.key_vault_object_id}"
+  key_permissions = [
+    "get",
+    "list",
+    "update",
+    "create",
+    "import",
+    "delete",
+  ]
+  secret_permissions = [
+    "get",
+    "list",
+    "set",
+    "delete",
+  ]
+  certificate_permissions = [
+    "get",
+    "list",
+    "update",
+    "create",
+    "import",
+    "delete",
+  ]
+}
 
-    key_permissions = [
-      "get",
-      "list",
-      "create",
-    ]
-
-    secret_permissions = [
-      "get",
-      "list",
-      "set",
-    ]
-  }
+resource "azurerm_key_vault_access_policy" "new-app" {
+  key_vault_id = "${azurerm_key_vault.new.id}"
+  tenant_id = "${var.key_vault_tenant_id}"
+  object_id = "${var.key_vault_object_id}"
+  application_id = "${var.application_id}"
+  key_permissions = [
+    "get",
+    "list",
+    "update",
+    "create",
+    "import",
+    "delete",
+  ]
+  secret_permissions = [
+    "get",
+    "list",
+    "set",
+    "delete",
+  ]
+  certificate_permissions = [
+    "get",
+    "list",
+    "update",
+    "create",
+    "import",
+    "delete",
+  ]
 }

--- a/examples/bootstrap-azure/variables.tf
+++ b/examples/bootstrap-azure/variables.tf
@@ -34,7 +34,11 @@ variable "key_vault_tenant_id" {
 }
 
 variable "key_vault_object_id" {
-  description = "The object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault."
+  description = "The object ID of the service principal for the vault."
+}
+
+variable "application_id" {
+  description = "The application ID of the service principal for the vault."
 }
 
 locals {


### PR DESCRIPTION
This allows the service principal to add the SSL certificates to the keyvault.