### PR TITLE
Fixed errors in the bootstrapping process for GCP by modifying the variables.tf, example.tfvars, module-dns-cert.tf, module-firewall.tf, modules/firewall-vpc/variables.tf, modules/firewall-vpc/vpc.tf, and README.md files

### DIFF
--- a/examples/bootstrap-google/README.md
+++ b/examples/bootstrap-google/README.md
@@ -1,12 +1,12 @@
-This module preps your gcp project for a v5 installs. This will create a vpc, subnet and firewall, as well as generate a certificate.
+This module prepares your GCP project for a v5 installation. This will create a VPC, subnet, firewall, and generate a certificate.
 
-## Pre-req
+## Prerequisites
 
 The only thing required to be previously conifgured is:
 
-- A DNS zone in gcp
-- A project
-- Valid credentials stored in json format
+- A GCP project
+- A DNS zone in the GCP project
+- Valid credentials for a service account stored in json format
 
 ## required variables
 
@@ -15,3 +15,11 @@ The only thing required to be previously conifgured is:
 - `domain` -- the domain to be used
 - `dnszone` -- the pre-configured dnszone
 
+## optional variables
+
+- `frontenddns` -- the prepended value to be added to your domain
+- `vpc_name` -- the name of the VPC to be created
+- `subnet_name` -- the name of the subnet to be created within the specified VPC
+- `subnet_range` -- the CIDR range to be allocated for the subnet
+- `primaryhostname` -- the hostname of the primary node(s)
+- `healthchk_ips` -- List of gcp health check ips to allow through the firewall (default value is suggested)

--- a/examples/bootstrap-google/example.tfvars
+++ b/examples/bootstrap-google/example.tfvars
@@ -2,5 +2,20 @@ region = "us-central1"
 primary_count = "3"
 zone = "us-central1-a"
 workercount = "0"
+
+// Project Specification
 project = "test-ptfe-project"
 creds = "test-ptfe-project-324fkj5383ur.json"
+
+// DNS Entries
+dnszone = "test-ptfe"
+frontenddns = "gcp"
+domain = "ptfe.com"
+
+// VPC and Subnets
+vpc_name = "test-ptfe"
+subnet_name = "test-ptfe-mgmt"
+subnet_range = "10.12.10.0/24"
+
+// Hostname of primary node
+primaryhostname = "test-ptfe-primary"

--- a/examples/bootstrap-google/module-dns-cert.tf
+++ b/examples/bootstrap-google/module-dns-cert.tf
@@ -1,5 +1,5 @@
 module "dns-cert" {
-  source   = "modules/dns-cert"
+  source   = "./modules/dns-cert"
   domain   = "${var.domain}"
   zone     = "${var.zone}"
   dnszone  = "${var.dnszone}"

--- a/examples/bootstrap-google/module-firewall.tf
+++ b/examples/bootstrap-google/module-firewall.tf
@@ -1,6 +1,8 @@
 module "firewall" {
-  source = "modules/firewall-vpc"
+  source = "./modules/firewall-vpc"
   region = "${var.region}"
   healthchk_ips = "${var.healthchk_ips}"
   subnet_range = "${var.subnet_range}"
+  subnet_name = "${var.subnet_name}"
+	vpc_name = "${var.vpc_name}"
 }

--- a/examples/bootstrap-google/modules/firewall-vpc/variables.tf
+++ b/examples/bootstrap-google/modules/firewall-vpc/variables.tf
@@ -8,6 +8,16 @@ variable "healthchk_ips" {
   description = "List of gcp health check ips to allow through the firewall"
 }
 
+variable "vpc_name" {
+	type				= "string"
+	description	= "VPC name for TFE"
+}
+
+variable "subnet_name" {
+	type				= "string"
+	description	= "Subnet name for TFE VPC"
+}
+
 variable "subnet_range" {
   type        = "string"
   description = "CIDR range for subnet"

--- a/examples/bootstrap-google/modules/firewall-vpc/vpc.tf
+++ b/examples/bootstrap-google/modules/firewall-vpc/vpc.tf
@@ -1,11 +1,11 @@
 resource "google_compute_network" "ptfe_vpc" {
-  name                    = "ptfevpc"
-  description             = "PTFE VPC Network"
+  name                    = "${var.vpc_name}"
+  description             = "TFE VPC Network"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "ptfe_subnet" {
-  name          = "ptfe-subnet"
+  name          = "${var.subnet_name}"
   ip_cidr_range = "${var.subnet_range}"
   region        = "${var.region}"
   network       = "${google_compute_network.ptfe_vpc.self_link}"

--- a/examples/bootstrap-google/variables.tf
+++ b/examples/bootstrap-google/variables.tf
@@ -48,6 +48,18 @@ variable "healthchk_ips" {
   default     = ["35.191.0.0/16", "209.85.152.0/22", "209.85.204.0/22", "130.211.0.0/22"]
 }
 
+variable "subnet_name" {
+	type				= "string"
+	description = "subnet name for VPC creation"
+	default			= "tfe_subnet"
+}
+
+variable "vpc_name" {
+	type				= "string"
+	description = "VPC name for TFE VPC"
+	default			= "tfe_vpc"
+}
+
 variable "subnet_range" {
   type        = "string"
   description = "CIDR range for subnet"


### PR DESCRIPTION
Modified variables.tf file to include:
	- added subnet_name variable
	- added vpc_name variable

Modified example.tfvars to include:
	- primaryhostname variable
	- vpc_name variable
	- subnet_name variable
	- subnet_range variable
	- domain variable
	- dnszone variable
	- frontenddns variable

Modified module-dns-cert.tf to fix the directory specification for the module source

Modified module-firewall.tf to fix the directory specification for the module source and to include the subnet_name and vpc_name variables

Modified modules/firewall-vpc/variables.tf to include subnet_name and vpc_name variables

Modified modules/firewall-vpc/vpc.tf to replace static vpc_name with the vpc_name variable as well as the subnet_name variable

Modified README.md to reflect the changes listed above and to include the optional variables