### PR TITLE
Updating example usages for bootstrap-aws

### DIFF
--- a/examples/bootstrap-aws/README.md
+++ b/examples/bootstrap-aws/README.md
@@ -12,8 +12,8 @@ This will create a VPC with subnets, and can create a Route53 zone.
 | cidr\_block | CIDR block range to use for the network. | string | `"10.0.0.0/16"` | no |
 | domain\_name | The domain to create a route53 zone for. (eg. `tfe.example.com`), will not create if left empty. | string | `""` | no |
 | prefix | The prefix to use on all resources, will generate one if not set. | string | `""` | no |
-| private\_subnet\_cidr\_block | CIDR block range to use for the private subnet. | string | `"10.0.128.0/17"` | no |
-| public\_subnet\_cidr\_block | CIDR block range to use for the public subnet. | string | `"10.0.0.0/17"` | no |
+| private\_subnet\_cidr\_block | CIDR block range to use for the private subnet. | list| `["10.0.11.0/24", "10.0.12.0/24", "10.0.13.0/24"]` | no |
+| public\_subnet\_cidr\_block | CIDR block range to use for the public subnet. | list | `["10.0.21.0/24", "10.0.22.0/24", "10.0.23.0/24"]` | no |
 
 ## Outputs
 

--- a/examples/bootstrap-aws/main.tf
+++ b/examples/bootstrap-aws/main.tf
@@ -13,8 +13,8 @@ module "new_vpc" {
   name                = "${local.prefix}-vpc"
   cidr                = "${var.cidr_block}"
   azs                 = ["${var.availability_zones}"]
-  private_subnets     = ["${var.private_subnet_cidr_block}"]
-  public_subnets      = ["${var.public_subnet_cidr_block}"]
+  private_subnets     = ["${var.private_subnet_cidr_blocks}"]
+  public_subnets      = ["${var.public_subnet_cidr_blocks}"]
   default_vpc_tags    = "${local.tags}"
   private_subnet_tags = "${local.tags}"
   public_subnet_tags  = "${local.tags}"

--- a/examples/bootstrap-aws/main.tf
+++ b/examples/bootstrap-aws/main.tf
@@ -8,7 +8,7 @@ resource "random_pet" "prefix" {
 module "new_vpc" {
   # 2.X.X versions of this module are for 0.12+ terraform
   source  = "terraform-aws-modules/vpc/aws"
-  version = "1.67.0"
+  version = "1.72.0"
 
   name                = "${local.prefix}-vpc"
   cidr                = "${var.cidr_block}"

--- a/examples/bootstrap-aws/variables.tf
+++ b/examples/bootstrap-aws/variables.tf
@@ -3,14 +3,16 @@ variable "cidr_block" {
   default     = "10.0.0.0/16"
 }
 
-variable "public_subnet_cidr_block" {
-  description = "CIDR block range to use for the public subnet."
-  default     = "10.0.0.0/17"
+variable "public_subnet_cidr_blocks" {
+  type        = "list"
+  description = "CIDR block ranges to use for the public subnets."
+  default     = ["10.0.21.0/24", "10.0.22.0/24", "10.0.23.0/24"]
 }
 
-variable "private_subnet_cidr_block" {
-  description = "CIDR block range to use for the private subnet."
-  default     = "10.0.128.0/17"
+variable "private_subnet_cidr_blocks" {
+  type        = "list"
+  description = "CIDR block ranges to use for the private subnets."
+  default     = ["10.0.11.0/24", "10.0.12.0/24", "10.0.13.0/24"]
 }
 
 variable "additional_tags" {
@@ -20,6 +22,7 @@ variable "additional_tags" {
 }
 
 variable "availability_zones" {
+  type        = "list"
   description = "List of the Availability zones to use."
   default     = ["us-east-2a", "us-east-2b", "us-east-2c"]
 }


### PR DESCRIPTION
These updates meet the requirements for Terraform Enterprise Clustering such as multiple subnets spanning across availability zones. I'm not sure if I should keep the subnets at /24 but I'm open to suggestions.