### PR TITLE
Updated service_principle_object_id to object_id

### DIFF
--- a/examples/bootstrap-azure/key_vault.tf
+++ b/examples/bootstrap-azure/key_vault.tf
@@ -13,7 +13,7 @@ resource "azurerm_key_vault" "new" {
 
   access_policy {                             # access policy for the current signed in user building the vault.
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
     key_permissions = [
     "backup",
     "create",


### PR DESCRIPTION
The `service_principle_object_id` attribute has been deprecated and is now accessible via `object_id`.

Without this change, the configuration errors stating that `service_principle_object_id` is empty.

- [AzureRM docs with the deprecation warning](https://registry.terraform.io/providers/hashicorp/azurerm/1.44.0/docs/data-sources/client_config)