### PR TITLE
Update user-data.tpl example to fix invalid JSON

### DIFF
--- a/examples/aws/user-data.tpl
+++ b/examples/aws/user-data.tpl
@@ -8,7 +8,7 @@ cat > /etc/replicated.conf <<EOF
   "TlsBootstrapType": "self-signed",
   "LogLevel": "debug",
   "ImportSettingsFrom": "/tmp/replicated-settings.json",
-  "LicenseFileLocation": "/tmp/license.rli"
+  "LicenseFileLocation": "/tmp/license.rli",
   "BypassPreflightChecks": true
 }
 EOF

--- a/examples/aws/user-data.tpl
+++ b/examples/aws/user-data.tpl
@@ -9,7 +9,7 @@ cat > /etc/replicated.conf <<EOF
   "LogLevel": "debug",
   "ImportSettingsFrom": "/tmp/replicated-settings.json",
   "LicenseFileLocation": "/tmp/license.rli",
-  "BypassPreflightChecks": true
+  "BypassPreflightChecks": true,
 }
 EOF
 cat > /tmp/replicated-settings.json <<EOF


### PR DESCRIPTION
Line 7 of the example `/etc/replicated.conf` contains invalid JSON syntax. Missing comma